### PR TITLE
Fix bibtex error when multiple included files.

### DIFF
--- a/LaTeX/Makefile
+++ b/LaTeX/Makefile
@@ -5,6 +5,9 @@ include Makefile.config
 ##### Shell
 SHELL		= /bin/bash
 
+##### Current directory. it's the directory containing the makefile.
+CURRENT_DIR = $(shell pwd)
+
 ##### Compilers
 PDFLATEX	= pdflatex
 DVILUATEX	= dviluatex
@@ -29,12 +32,13 @@ $(NAME): $(OUTPUT_DIR)
     -output-directory=$(OUTPUT_DIR) \
     $(NAME).tex
 ifeq ($(USE_BIB),true)
-	sed 's/@input{/@input{$(OUTPUT_DIR)\//g' -i $(OUTPUT_DIR)/$(NAME).aux
-	BIBINPUTS="$(SRC_DIR)" \
-    BSTINPUT="$(SRC_DIR)" \
-    TEXMFOUTPUTS="$(OUTPUT_DIR)/" \
+	cd $(OUTPUT_DIR) && \
+    BIBINPUTS="$(CURRENT_DIR)/$(SRC_DIR)" \
+    BSTINPUT="$(CURRENT_DIR)/$(SRC_DIR)" \
+    TEXMFOUTPUTS="./" \
     $(CC_BIB) \
-    $(OUTPUT_DIR)/$(NAME)
+    $(NAME) && \
+    cd $(CURRENT_DIR)
 	TEXINPUTS="$(SRC_DIR):" \
     TEXMFOUTPUTS="$(OUTPUT_DIR)/" \
     $(CC) \
@@ -65,4 +69,4 @@ fclean: clean
 re: fclean $(NAME)
 ################################################################################
 
-.PHONY: all $(NAME) zip clean fclean re
+.PHONY: all $(NAME) zip clean fclean re $(BBL_FILES)

--- a/LaTeX/Makefile
+++ b/LaTeX/Makefile
@@ -9,6 +9,10 @@ SHELL		= /bin/bash
 PDFLATEX	= pdflatex
 DVILUATEX	= dviluatex
 BIBTEX		= bibtex
+
+##### Intermediate files.
+AUX_FILES = $(addprefix $(OUTPUT_DIR)/, $(addsuffix .aux, $(INCLUDED_TEX_FILES)))
+
 ################################################################################
 
 ################################################################################
@@ -16,22 +20,33 @@ BIBTEX		= bibtex
 all: $(NAME)
 
 $(OUTPUT_DIR):
-	mkdir -p $(OUTPUT_DIR)
+	mkdir -p $@
 
 $(NAME): $(OUTPUT_DIR)
-	TEXINPUTS="$(SRC_DIR):" $(CC) -output-directory $(OUTPUT_DIR) \
-                                 $(SRC_DIR)/$(NAME)
+	TEXINPUTS="$(SRC_DIR):" \
+    TEXMFOUTPUTS="$(OUTPUT_DIR)" \
+    $(CC) \
+    -output-directory=$(OUTPUT_DIR) \
+    $(NAME).tex
 ifeq ($(USE_BIB),true)
-	BIBINPUTS="$(SRC_DIR):" \
-    BSTINPUT="$(SRC_DIR):" \
-    TEXMFOUTPUTS="$(OUTPUT_DIR):" \
-    $(CC_BIB) $(OUTPUT_DIR)/$(NAME)
-	TEXINPUTS="$(SRC_DIR):" $(CC) -output-directory $(OUTPUT_DIR) \
-                                 $(SRC_DIR)/$(NAME)
+	sed 's/@input{/@input{$(OUTPUT_DIR)\//g' -i $(OUTPUT_DIR)/$(NAME).aux
+	BIBINPUTS="$(SRC_DIR)" \
+    BSTINPUT="$(SRC_DIR)" \
+    TEXMFOUTPUTS="$(OUTPUT_DIR)/" \
+    $(CC_BIB) \
+    $(OUTPUT_DIR)/$(NAME)
+	TEXINPUTS="$(SRC_DIR):" \
+    TEXMFOUTPUTS="$(OUTPUT_DIR)/" \
+    $(CC) \
+    -output-directory=$(OUTPUT_DIR) \
+    $(SRC_DIR)/$(NAME).tex
 else
 endif
-	TEXINPUTS="$(SRC_DIR):" $(CC) -output-directory $(OUTPUT_DIR) \
-                                 $(SRC_DIR)/$(NAME)
+	TEXINPUTS="$(SRC_DIR):" \
+    TEXMFOUTPUTS="$(OUTPUT_DIR)/" \
+    $(CC) \
+    -output-directory=$(OUTPUT_DIR) \
+    $(SRC_DIR)/$(NAME).tex
 
 zip: fclean $(NAME)
 	$(MAKE) clean
@@ -39,6 +54,7 @@ zip: fclean $(NAME)
 
 clean:
 	$(RM) $(OUTPUT_DIR)/$(NAME).{out,aux,toc,log,tex.backup,nav,snm,bbl,blg}
+	$(RM) $(AUX_FILES)
 
 # $(OUTPUT_DIR) is only removed when the directory is empty (never be the case
 # if it's the project root directory).

--- a/LaTeX/Makefile.config
+++ b/LaTeX/Makefile.config
@@ -1,17 +1,19 @@
 ################################################################################
 ############################ Variables to change ###############################
 ##### Sources directory
-SRC_DIR		=
+SRC_DIR            =
 
 ##### Main file, without .tex extension.
-NAME		=
+NAME               =
 
-##### Output directory
-# If not modified, it is the directory which holds the MakeFile
-OUTPUT_DIR	=
+##### Included TeX files in the main file $(NAME).tex.
+INCLUDED_TEX_FILES =
+##### Output directory (without / at the end).
+# If not modified, it is the directory which holds the MakeFile.
+OUTPUT_DIR         =
 
 ##### Executable/output to use: PDFLATEX, DVILUATEX
-CC			= $(PDFLATEX)
-CC_BIB		= $(BIBTEX)
-USE_BIB		= false
+CC                 = $(PDFLATEX)
+CC_BIB             = $(BIBTEX)
+USE_BIB            = false
 ################################################################################


### PR DESCRIPTION
Fix #6.

It also removes other generated `aux` files if `\include` or `\input` is used. It implies to know all `tex` included files (so `INCLUDED_TEX_FILES` is defined).